### PR TITLE
[fixbug] 纳秒小于1000时nsecStr[0:4]数组超出下标范围

### DIFF
--- a/util/log/Logger.go
+++ b/util/log/Logger.go
@@ -29,6 +29,7 @@ var lock sync.Mutex
 var level LogLevel
 var log *Logger
 var logPath string
+var zero = [...]string{"0000", "000", "00", "0"}
 
 func init() {
 	level = InfoLevel
@@ -100,6 +101,12 @@ func currTime() string {
 	now := time.Now()
 	const base_format = "2006-01-02 15:04:05"
 	nsecStr := strconv.Itoa(now.Nanosecond())
-	timeStr := now.Format(base_format) + "." + nsecStr[0:4]
+	nsecLen := len(nsecStr)
+	if nsecLen < 4 {
+		nsecStr = nsecStr[0:nsecLen] + zero[nsecLen]
+	} else {
+		nsecStr = nsecStr[0:4]
+	}
+	timeStr := now.Format(base_format) + "." + nsecStr
 	return timeStr
 }


### PR DESCRIPTION
[fixbug] nanosecond in the range [0, 999999999]. 纳秒小于1000时nsecStr[0:4]数组超出下标范围

panic: runtime error: slice bounds out of range [:4] with length 2

goroutine 1366 [running]:
github.com/Xiaomi-mimc/mimc-go-sdk/util/log.currTime(0xc000134230, 0x2)
        /home/ubuntu/go/pkg/mod/github.com/!xiaomi-mimc/mimc-go-sdk@v0.0.0-20190916145029-9c8d2e5e0f4c/util/log/Logger.go:103 +0x12e
github.com/Xiaomi-mimc/mimc-go-sdk/util/log.(*Logger).Info(0xc000125320, 0xd2686f, 0x26, 0xc0000dded8, 0x1, 0x1)
        /home/ubuntu/go/pkg/mod/github.com/!xiaomi-mimc/mimc-go-sdk@v0.0.0-20190916145029-9c8d2e5e0f4c/util/log/Logger.go:71 +0x125
github.com/Xiaomi-mimc/mimc-go-sdk.(*MCUser).handleResponse(0xc0001b6160, 0xc000496370)
        /home/ubuntu/go/pkg/mod/github.com/!xiaomi-mimc/mimc-go-sdk@v0.0.0-20190916145029-9c8d2e5e0f4c/MCUser.go:644 +0x1295
github.com/Xiaomi-mimc/mimc-go-sdk.(*MCUser).callBackRoutine(0xc0001b6160)
        /home/ubuntu/go/pkg/mod/github.com/!xiaomi-mimc/mimc-go-sdk@v0.0.0-20190916145029-9c8d2e5e0f4c/MCUser.go:593 +0x141
created by github.com/Xiaomi-mimc/mimc-go-sdk.(*MCUser).InitAndSetup
        /home/ubuntu/go/pkg/mod/github.com/!xiaomi-mimc/mimc-go-sdk@v0.0.0-20190916145029-9c8d2e5e0f4c/MCUser.go:153 +0x468
(END)packet_write_wait: Connection to 172.21.212.15 port 32200: Broken pipe